### PR TITLE
1️⃣ 스터디 게시글 목록 페이지 기능 구현

### DIFF
--- a/src/components/modules/board/Board.jsx
+++ b/src/components/modules/board/Board.jsx
@@ -50,7 +50,6 @@ const Board = () => {
     staleTime: 1000 * 10, // 10초 동안 refetch 안 함
   });
 
-  if (data) console.log(data);
   return (
     <div className="lg:mx-0 md:-mx-8 sm:-mx-6">
       <BoardTitle title={title[boardType]} />

--- a/src/components/modules/board/Board.jsx
+++ b/src/components/modules/board/Board.jsx
@@ -51,7 +51,6 @@ const Board = () => {
     staleTime: 1000 * 10,
   });
 
-  console.log(data);
   return (
     <div className="lg:mx-0 md:-mx-8 sm:-mx-6">
       <BoardTitle title={title[boardType]} />

--- a/src/components/modules/board/Board.jsx
+++ b/src/components/modules/board/Board.jsx
@@ -7,30 +7,12 @@ import BoardListItem from '@components/modules/board/BoardListItem';
 import DropdownBox from '@components/common/DropdownBox';
 import useMediaQuery from '@hooks/useMediaQuery';
 import { useQuery } from '@tanstack/react-query';
-import { getPostListByType } from '@queries/getStudyPostListByType';
+import { getPostListByType } from '@queries/getPostListByType';
 
 const title = {
   notice: '공지사항',
   debate: '토론 나눠요',
 };
-
-const postList = [
-  {
-    id: 1,
-    title: '첫번째 게시글',
-    content: '첫번째 게시글의 내용입니다.',
-  },
-  {
-    id: 2,
-    title: '두번째 게시글',
-    content: '두번째 게시글의 내용입니다.',
-  },
-  {
-    id: 3,
-    title: '세번째 게시글',
-    content: '세번째 게시글의 내용입니다.',
-  },
-];
 
 const options = [
   { name: '조회수 많은 순', value: 'mostViewed' },
@@ -59,7 +41,7 @@ const Board = () => {
 
   const md = useMediaQuery('(min-width: 768px)');
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['posts', boardType],
     queryFn: () => {
       return getPostListByType(studyId, boardType);
@@ -102,9 +84,8 @@ const Board = () => {
             </div>
           </div>
           <hr className="md:hidden h-px border-0 bg-slate-500" />
-          {postList.map((post) => (
-            <BoardListItem key={post.id} post={post} />
-          ))}
+          {!isLoading &&
+            data.map((item) => <BoardListItem key={item.id} postData={item} />)}
         </div>
         <div className="h-[64px] flex items-center justify-center">
           <Pagination

--- a/src/components/modules/board/Board.jsx
+++ b/src/components/modules/board/Board.jsx
@@ -6,10 +6,12 @@ import BoardTitle from '@components/modules/board/BoardTitle';
 import BoardListItem from '@components/modules/board/BoardListItem';
 import DropdownBox from '@components/common/DropdownBox';
 import useMediaQuery from '@hooks/useMediaQuery';
+import { useQuery } from '@tanstack/react-query';
+import { getPostListByType } from '@queries/getStudyPostListByType';
 
 const title = {
-  notices: '공지사항',
-  debates: '토론 나눠요',
+  notice: '공지사항',
+  debate: '토론 나눠요',
 };
 
 const postList = [
@@ -56,6 +58,17 @@ const Board = () => {
   }, [boardType]);
 
   const md = useMediaQuery('(min-width: 768px)');
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['posts', boardType],
+    queryFn: () => {
+      return getPostListByType(studyId, boardType);
+    },
+    select: (res) => res.data,
+    staleTime: 1000 * 10, // 10초 동안 refetch 안 함
+  });
+
+  if (data) console.log(data);
   return (
     <div className="lg:mx-0 md:-mx-8 sm:-mx-6">
       <BoardTitle title={title[boardType]} />

--- a/src/components/modules/board/Board.jsx
+++ b/src/components/modules/board/Board.jsx
@@ -51,6 +51,7 @@ const Board = () => {
     staleTime: 1000 * 10,
   });
 
+  console.log(data);
   return (
     <div className="lg:mx-0 md:-mx-8 sm:-mx-6">
       <BoardTitle title={title[boardType]} />

--- a/src/components/modules/board/Board.jsx
+++ b/src/components/modules/board/Board.jsx
@@ -44,10 +44,11 @@ const Board = () => {
   const { data, isLoading } = useQuery({
     queryKey: ['posts', boardType],
     queryFn: () => {
+      console.log('게시글 목록 조회');
       return getPostListByType(studyId, boardType);
     },
     select: (res) => res.data,
-    staleTime: 1000 * 10, // 10초 동안 refetch 안 함
+    staleTime: 1000 * 10,
   });
 
   return (

--- a/src/components/modules/board/BoardListItem.jsx
+++ b/src/components/modules/board/BoardListItem.jsx
@@ -3,6 +3,7 @@ import commentIcon from '@assets/icons/icon_comment_24.svg';
 import eyeIcon from '@assets/icons/icon_eye_24.svg';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router';
+import { getRecentActivity } from '@utils/time';
 
 const BoardListItem = ({ postData }) => {
   const navigate = useNavigate();
@@ -16,22 +17,24 @@ const BoardListItem = ({ postData }) => {
     >
       <div className="md:flex-3/5 sm:w-full">{postData.title}</div>
       <div className="md:flex-2/5 sm:w-full flex text-center justify-end">
-        <img
-          className="md:flex-1 md:ml-0 ml-4 w-2 flex justify-center items-center object-cover rounded-full"
-          src={
-            postData.users?.img_url ? postData.users.img_url : defaultProfile
-          }
-        />
+        <div className="md:flex-1 md:ml-0 ml-4 flex justify-center items-center">
+          <img
+            className="size-7 object-cover rounded-full"
+            src={
+              postData.users?.img_url ? postData.users.img_url : defaultProfile
+            }
+          />
+        </div>
         <div className="md:flex-1 md:ml-0 ml-4 text-center flex justify-center items-center">
           <img src={commentIcon} className="mr-1" />
-          <span>4</span>
+          <span>{postData.comment_count}</span>
         </div>
         <div className="md:flex-1 md:ml-0 ml-4 text-center flex justify-center items-center">
           <img src={eyeIcon} className="mr-1" />
-          <span>6</span>
+          <span>{postData.views}</span>
         </div>
         <div className="md:flex-1 md:ml-0 ml-4 text-center flex justify-center items-center">
-          1일 전
+          {getRecentActivity(postData.recent_activity)}
         </div>
       </div>
     </div>
@@ -44,6 +47,9 @@ BoardListItem.propTypes = {
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
     users: PropTypes.object.isRequired,
+    comment_count: PropTypes.number.isRequired,
+    views: PropTypes.number.isRequired,
+    recent_activity: PropTypes.string.isRequired,
   }),
 };
 

--- a/src/components/modules/board/BoardListItem.jsx
+++ b/src/components/modules/board/BoardListItem.jsx
@@ -35,7 +35,7 @@ const BoardListItem = ({ postData }) => {
       }}
     >
       <div className="md:flex-3/5 sm:w-full">{postData.title}</div>
-      <div className="md:flex-2/5 sm:w-full flex gap-4 text-center justify-end">
+      <div className="md:flex-2/5 sm:w-full flex md:gap-0 gap-4 text-center justify-end">
         <div className="md:flex-1 md:ml-0 flex justify-center items-center">
           {participantList}
           {remainingCount > 0 && (

--- a/src/components/modules/board/BoardListItem.jsx
+++ b/src/components/modules/board/BoardListItem.jsx
@@ -4,36 +4,28 @@ import eyeIcon from '@assets/icons/icon_eye_24.svg';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router';
 import { getRecentActivity } from '@utils/time';
-import { useQuery } from '@tanstack/react-query';
-import { getUserListById } from '@queries/getUserListById';
 
 const BoardListItem = ({ postData }) => {
   const navigate = useNavigate();
 
-  const { data } = useQuery({
-    queryKey: ['post', 'participants', postData.id],
-    queryFn: () => {
-      console.log('참가자 유저 정보 조회');
-      return getUserListById(postData.participants);
-    },
-    select: (res) => res.data,
-    staleTime: 1000 * 10, // 10초 동안 refetch 안 함
-  });
-
   const participantList =
-    data &&
-    data.slice(0, 4).map((item, index) => {
+    postData &&
+    postData.post_participants.slice(0, 4).map((participant, index) => {
       return (
         <img
-          key={item.id}
-          title={item.nickname}
+          key={participant.users.id}
+          title={participant.users.nickname}
           className={`size-7 object-cover rounded-full ${index !== 0 ? '-ml-2' : ''}`}
-          src={item.img_url ? item.img_url : defaultProfile}
+          src={
+            participant.users.img_url
+              ? participant.users.img_url
+              : defaultProfile
+          }
         />
       );
     });
 
-  const remainingCount = data && data.length - 4;
+  const remainingCount = postData && postData.post_participants.length - 4;
 
   return (
     <div
@@ -43,8 +35,8 @@ const BoardListItem = ({ postData }) => {
       }}
     >
       <div className="md:flex-3/5 sm:w-full">{postData.title}</div>
-      <div className="md:flex-2/5 sm:w-full flex text-center justify-end">
-        <div className="md:flex-1 md:ml-0 ml-4 flex justify-center items-center">
+      <div className="md:flex-2/5 sm:w-full flex gap-4 text-center justify-end">
+        <div className="md:flex-1 md:ml-0 flex justify-center items-center">
           {participantList}
           {remainingCount > 0 && (
             <div
@@ -55,15 +47,15 @@ const BoardListItem = ({ postData }) => {
             </div>
           )}
         </div>
-        <div className="md:flex-1 md:ml-0 ml-4 text-center flex justify-center items-center">
+        <div className="md:flex-1 md:ml-0 text-center flex justify-center items-center">
           <img src={commentIcon} className="mr-1" />
           <span>{postData.comment_count}</span>
         </div>
-        <div className="md:flex-1 md:ml-0 ml-4 text-center flex justify-center items-center">
+        <div className="md:flex-1 md:ml-0 text-center flex justify-center items-center">
           <img src={eyeIcon} className="mr-1" />
           <span>{postData.views}</span>
         </div>
-        <div className="md:flex-1 md:ml-0 ml-4 text-center flex justify-center items-center">
+        <div className="md:flex-1 md:ml-0 text-center flex justify-center items-center">
           {getRecentActivity(postData.recent_activity)}
         </div>
       </div>
@@ -76,11 +68,10 @@ BoardListItem.propTypes = {
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
-    users: PropTypes.object.isRequired,
     comment_count: PropTypes.number.isRequired,
     views: PropTypes.number.isRequired,
     recent_activity: PropTypes.string.isRequired,
-    participants: PropTypes.array.isRequired,
+    post_participants: PropTypes.array.isRequired,
   }),
 };
 

--- a/src/components/modules/board/BoardListItem.jsx
+++ b/src/components/modules/board/BoardListItem.jsx
@@ -4,21 +4,23 @@ import eyeIcon from '@assets/icons/icon_eye_24.svg';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router';
 
-const BoardListItem = ({ post }) => {
+const BoardListItem = ({ postData }) => {
   const navigate = useNavigate();
 
   return (
     <div
       className="lg:px-6 px-4 md:min-h-12 py-2 flex items-center border-b-1 border-slate-500 cursor-pointer md:flex-row flex-col md:gap-0 gap-2"
       onClick={() => {
-        return navigate(`${post.id}`);
+        return navigate(`${postData.id}`);
       }}
     >
-      <div className="md:flex-3/5 sm:w-full">{post.title}</div>
+      <div className="md:flex-3/5 sm:w-full">{postData.title}</div>
       <div className="md:flex-2/5 sm:w-full flex text-center justify-end">
         <img
-          className="md:flex-1 md:ml-0 ml-4 size-8 flex justify-center items-center"
-          src={defaultProfile}
+          className="md:flex-1 md:ml-0 ml-4 w-2 flex justify-center items-center object-cover rounded-full"
+          src={
+            postData.users?.img_url ? postData.users.img_url : defaultProfile
+          }
         />
         <div className="md:flex-1 md:ml-0 ml-4 text-center flex justify-center items-center">
           <img src={commentIcon} className="mr-1" />
@@ -37,10 +39,11 @@ const BoardListItem = ({ post }) => {
 };
 
 BoardListItem.propTypes = {
-  post: PropTypes.shape({
+  postData: PropTypes.shape({
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
+    users: PropTypes.object.isRequired,
   }),
 };
 

--- a/src/components/modules/board/BoardListItem.jsx
+++ b/src/components/modules/board/BoardListItem.jsx
@@ -13,6 +13,7 @@ const BoardListItem = ({ postData }) => {
   const { data } = useQuery({
     queryKey: ['post', 'participants', postData.id],
     queryFn: () => {
+      console.log('참가자 유저 정보 조회');
       return getUserListById(postData.participants);
     },
     select: (res) => res.data,
@@ -21,12 +22,12 @@ const BoardListItem = ({ postData }) => {
 
   const participantList =
     data &&
-    data.slice(0, 4).map((item) => {
+    data.slice(0, 4).map((item, index) => {
       return (
         <img
           key={item.id}
           title={item.nickname}
-          className="size-7 object-cover rounded-full -ml-1"
+          className={`size-7 object-cover rounded-full ${index !== 0 ? '-ml-2' : ''}`}
           src={item.img_url ? item.img_url : defaultProfile}
         />
       );
@@ -47,7 +48,7 @@ const BoardListItem = ({ postData }) => {
           {participantList}
           {remainingCount > 0 && (
             <div
-              className="size-7 shrink-0 flex items-center justify-center rounded-full bg-gray-200 text-xs text-gray-600 font-medium -ml-1"
+              className="size-7 shrink-0 flex items-center justify-center rounded-full bg-gray-200 text-xs text-gray-600 font-medium -ml-2"
               title={`외 ${remainingCount}명`}
             >
               +{remainingCount}

--- a/src/components/modules/post/PostDetail.jsx
+++ b/src/components/modules/post/PostDetail.jsx
@@ -8,8 +8,8 @@ import { useForm } from 'react-hook-form';
 import useMediaQuery from '@hooks/useMediaQuery';
 
 const commentPlaceholder = {
-  notices: '게시글에 댓글을 남겨 보세요.',
-  debates: '토론 주제에 대한 자신의 생각을 남겨보세요.',
+  notice: '게시글에 댓글을 남겨 보세요.',
+  debate: '토론 주제에 대한 자신의 생각을 남겨보세요.',
 };
 
 const post = {

--- a/src/components/modules/post/PostEdit.jsx
+++ b/src/components/modules/post/PostEdit.jsx
@@ -5,8 +5,8 @@ import { useForm } from 'react-hook-form';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
 const title = {
-  notices: '공지사항 글 수정',
-  debates: '토론 글 수정',
+  notice: '공지사항 글 수정',
+  debate: '토론 글 수정',
 };
 
 const PostEdit = () => {

--- a/src/components/modules/post/PostWrite.jsx
+++ b/src/components/modules/post/PostWrite.jsx
@@ -4,18 +4,18 @@ import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router';
 
 const title = {
-  notices: '공지사항 글 작성',
-  debates: '토론 글 작성',
+  notice: '공지사항 글 작성',
+  debate: '토론 글 작성',
 };
 
 const titlePlaceholder = {
-  notices: '공지사항 제목을 입력해주세요.',
-  debates: '함께 토론하고 싶은 주제를 입력해 주세요.',
+  notice: '공지사항 제목을 입력해주세요.',
+  debate: '함께 토론하고 싶은 주제를 입력해 주세요.',
 };
 
 const contentPlaceholder = {
-  notices: '공지사항 내용을 입력해주세요.',
-  debates: '토론 주제에 대한 내용을 입력해 주세요.',
+  notice: '공지사항 내용을 입력해주세요.',
+  debate: '토론 주제에 대한 내용을 입력해 주세요.',
 };
 
 const PostWrite = () => {

--- a/src/pages/study/detail/StudyDetailLayout.jsx
+++ b/src/pages/study/detail/StudyDetailLayout.jsx
@@ -10,11 +10,11 @@ const pages = [
     title: '스터디 홈',
   },
   {
-    route: 'notices',
+    route: 'notice',
     title: '공지사항',
   },
   {
-    route: 'debates',
+    route: 'debate',
     title: '토론 나눠요',
   },
   {

--- a/src/queries/getPostListByType.js
+++ b/src/queries/getPostListByType.js
@@ -3,7 +3,19 @@ import supabase from '@libs/supabase';
 export const getPostListByType = (studyId, type) => {
   return supabase
     .from('posts')
-    .select(`*,users(id, nickname, img_url)`)
+    .select(
+      `*,
+       post_participants (
+        user_id,
+        is_writer,
+        users (
+          id,
+          nickname,
+          img_url
+        )
+      )
+      `,
+    )
     .eq('type', type)
     .eq('study_id', studyId);
 };

--- a/src/queries/getPostListByType.js
+++ b/src/queries/getPostListByType.js
@@ -3,7 +3,7 @@ import supabase from '@libs/supabase';
 export const getPostListByType = (studyId, type) => {
   return supabase
     .from('posts')
-    .select(`*`)
+    .select(`*,users(id, nickname, img_url)`)
     .eq('type', type)
     .eq('study_id', studyId);
 };

--- a/src/queries/getStudyPostListByType.js
+++ b/src/queries/getStudyPostListByType.js
@@ -1,0 +1,9 @@
+import supabase from '@libs/supabase';
+
+export const getPostListByType = (studyId, type) => {
+  return supabase
+    .from('posts')
+    .select(`*`)
+    .eq('type', type)
+    .eq('study_id', studyId);
+};

--- a/src/queries/getUserListById.js
+++ b/src/queries/getUserListById.js
@@ -1,8 +1,0 @@
-import supabase from '@libs/supabase';
-
-export const getUserListById = (userIdList) => {
-  return supabase
-    .from('users')
-    .select('id, nickname, img_url')
-    .in('id', userIdList);
-};

--- a/src/queries/getUserListById.js
+++ b/src/queries/getUserListById.js
@@ -1,0 +1,8 @@
+import supabase from '@libs/supabase';
+
+export const getUserListById = (userIdList) => {
+  return supabase
+    .from('users')
+    .select('id, nickname, img_url')
+    .in('id', userIdList);
+};

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,20 @@
+export const getRecentActivity = (timestamptz) => {
+  const diff = new Date() - new Date(timestamptz);
+
+  const sec = diff / 1000;
+  const min = sec / 60;
+  const hours = min / 60;
+  const days = hours / 24;
+
+  if (min < 0) {
+    return '방금 전';
+  } else if (min < 60) {
+    return `${Math.round(min)}분 전`;
+  } else if (hours < 24) {
+    return `${Math.round(hours)}시간 전`;
+  } else if (days < 2) {
+    return '하루 전';
+  } else {
+    return new Date(timestamptz).toLocaleDateString();
+  }
+};


### PR DESCRIPTION
# Pull Request

## 🔢 Issue Number

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves #54 

## 📝 요약

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

스터디 게시판(공지사항, 토론 게시판) 페이지 첫 화면에서 DB에 있는 게시글 리스트가 보이는 것 까지 구현했습니다.

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📋 변경사항 상세 설명

<!--- 필요한 경우 중요한 변경사항에 대해 더 자세히 설명해주세요 -->
### 주요 기능 (테스트 부탁드립니다!)
![image](https://github.com/user-attachments/assets/a20b2fb3-433c-45e5-a940-5ea968562abc)

- 댓글을 작성한 유저가 게시글 목록 아이템에서 참여자에 표시됩니다.
- 참여자가 4명 이상일 경우에는 +1과 같이 표시됩니다.
- 프로필 이미지에 마우스 호버시 닉네임이 표시됩니다.

### 시간 관련 util 함수
- src/utils/time.js 파일에 getRecentActivity 함수를 만들었습니다.
- db에 있는 created_at 스트링 값을 넣으면 방금 전, 1분 전, 1시간 전, 하루 전이 구분돼서 나오고, 더 오래됐을 경우 2025. 03. 27.처럼 날짜가 리턴됩니다.

<img src="https://github.com/user-attachments/assets/1f771564-1cc5-4ec8-aed3-dd64ddb63f44" width="100px" />

### DB 변경 사항
**post_participants 테이블**
- 게시글 참여자를 나타내는 post_participants 테이블을 만들었습니다.
- post_participants 테이블은 user_id, post_id, is_writer 컬럼을 가지고 있습니다.
- 새로운 post가 등록되거나, post에 comment가 등록되면 post_participants 테이블이 업데이트 되도록 트리거를 설정했습니다.


**posts 테이블**
-  posts 테이블에 comment_count 컬럼을 생성하고 자동으로 값이 업데이트 되게 트리거를 설정했습니다.

## 🖼️ 스크린샷 및 데모

<!--- UI 변경사항이 있는 경우 스크린샷이나 GIF/동영상을 첨부해주세요 -->

## 👀 리뷰어

<!--- 이 PR의 리뷰를 요청할 담당자를 지정해주세요 -->
<!-- 예시: @username -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 브랜치가 최신 상태의 메인 브랜치와 병합 가능합니다.

## 📢 특이사항

<!--- 리뷰어가 알아야 할 주의사항이나 특이점이 있다면 여기에 작성해주세요 -->
정렬, 페이지네이션 등 다른 기능은 이슈를 나눠서 작업할 예정입니다.